### PR TITLE
Changed to async_forward_entry_setups.

### DIFF
--- a/custom_components/solaredgeoptimizers/__init__.py
+++ b/custom_components/solaredgeoptimizers/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {DATA_API_CLIENT: api}
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
From 2023.3 async_setup_platforms can no longer be used. So switched to await async_forward_entry_setups