### PR TITLE
Removed via_device

### DIFF
--- a/custom_components/solaredgeoptimizers/sensor.py
+++ b/custom_components/solaredgeoptimizers/sensor.py
@@ -251,7 +251,6 @@ class SolarEdgeOptimizersSensor(CoordinatorEntity, SensorEntity):
             "manufacturer": self._paneelobject.manufacturer,
             "model": self._paneelobject.model,
             "hw_version": self._paneelobject.serialnumber,
-            "via_device": (DOMAIN, self._entry.entry_id),
         }
 
     @callback


### PR DESCRIPTION
Removed the `via_device` in `def device_info` as it referencing a device that is never created by this integration. This fix changes nothing, but makes sure that the deprecation message _'solaredgeoptimizers' calls device_registry.async_get_or_create referencing a non existing via_device. This will stop working in Home Assistant 2025.12.0_ disappears.

Fixes #82 
Fixes #84